### PR TITLE
Optimize Dockerfile for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 continuumio/miniconda3:23.10.0-1
+FROM --platform=linux/amd64 continuumio/miniconda3:23.10.0-1 AS build
 
 LABEL maintainer=nigyta
 
@@ -10,21 +10,26 @@ ENV CHECKM_DATA_PATH /dqc_reference/checkm_data
 
 RUN cd / && \
 	mkdir /work && chmod 777 /work && \
-	pip install checkm-genome && \
-	conda install -y -c bioconda -c conda-forge mash skani gsl==2.6 hmmer prodigal
+	pip install checkm-genome --no-cache-dir && \
+	conda install -y -c bioconda -c conda-forge mash skani gsl==2.6 hmmer prodigal && \
+	conda clean --all -y
 
-RUN pip install ete3 more-itertools peewee
+RUN pip install ete3 more-itertools peewee --no-cache-dir
+RUN	git clone https://github.com/nigyta/dfast_qc.git
 
+FROM debian:bookworm-slim
 ENV DQC_VERSION 1.0.0-1
 
-RUN	git clone https://github.com/nigyta/dfast_qc.git && \
-    ln -s /dfast_qc/dfast_qc /usr/local/bin/ && \
+COPY --from=build /opt/conda/. /opt/conda/
+COPY --from=build /dfast_qc /dfast_qc
+ENV PATH /opt/conda/bin:$PATH
+
+RUN ln -s /dfast_qc/dfast_qc /usr/local/bin/ && \
 	ln -s /dfast_qc/dqc_admin_tools.py /usr/local/bin/ && \
 	ln -s /dfast_qc/initial_setup.sh /usr/local/bin/ && \
 	ln -s /dfast_qc/dqc_ref_manager.py  /usr/local/bin/ && \
 	mkdir -p /dqc_reference/checkm_data && \
-	checkm data setRoot /dqc_reference/checkm_data && \
-	conda clean --all -y
+	checkm data setRoot /dqc_reference/checkm_data
 
 WORKDIR /work
 CMD bash


### PR DESCRIPTION
This commit optimizes the Dockerfile to significantly reduce the image size by:

- **Eliminating cache directories**: Removes the conda and pip cache directories to reduce unnecessary bloat.
- **Implementing multi-stage builds**: Utilizes a multi-stage build process to separate build dependencies from the final runtime image, further minimizing the image size.

This optimization results in a substantial reduction in image size:

- **Docker image size:** 1.93GB -> 922MB
- **Docker Hub compressed size**: 647MB -> 290MB